### PR TITLE
inject current user identifiers into all payloads

### DIFF
--- a/lytics-sdk/src/main/java/com/lytics/android/Lytics.kt
+++ b/lytics-sdk/src/main/java/com/lytics/android/Lytics.kt
@@ -198,13 +198,6 @@ object Lytics {
         logger.info("Track Event: $event")
 
         val payload = Payload(event)
-        // inject current user identifiers into payload
-        currentUser?.let { user ->
-            user.identifiers?.let {
-                payload.identifiers = (payload.identifiers ?: emptyMap()).plus(it)
-            }
-        }
-
         submitPayload(payload)
     }
 
@@ -219,13 +212,6 @@ object Lytics {
         // inject custom event type of "sc"
         payload.data = (payload.data ?: emptyMap())
             .plus(mapOf(Constants.KEY_EVENT_TYPE to Constants.KEY_SCREEN_EVENT_TYPE))
-
-        // inject current user identifiers into payload
-        currentUser?.let { user ->
-            user.identifiers?.let {
-                payload.identifiers = (payload.identifiers ?: emptyMap()).plus(it)
-            }
-        }
 
         submitPayload(payload)
     }
@@ -288,6 +274,13 @@ object Lytics {
             if (sessionStart.getAndSet(false)) {
                 payload.data =
                     payload.data?.plus(mapOf(Constants.KEY_SESSION_START to Constants.KEY_SESSION_START_FLAG))
+            }
+
+            // inject current user identifiers into payload
+            currentUser?.let { user ->
+                user.identifiers?.let { userIdentifiers ->
+                    payload.identifiers = userIdentifiers.plus(payload.identifiers ?: emptyMap())
+                }
             }
 
             // if IDFA is enabled, try and get the Android Advertising ID and update the payload identifiers


### PR DESCRIPTION
previously just track and custom events were getting injected with the current user identifiers.

closes #41 

```
Identify Event: LyticsIdentityEvent(stream=null, name=login1, identifiers={email1=mark1@test.com}, attributes=null, sendEvent=true)
Identify Event: LyticsIdentityEvent(stream=null, name=login2, identifiers={email2=mark2@test.com}, attributes=null, sendEvent=true)
Adding payload to queue: Payload(id=null, stream=defaultStream, data={eventName=login1, _ts=1669227137168}, identifiers={_uid=25641814-46fb-4a39-b53d-e13e762088af, email1=mark1@test.com}, attributes=null, properties=null, consent=null)
Adding payload to queue: Payload(id=null, stream=defaultStream, data={eventName=login2, _ts=1669227137172}, identifiers={_uid=25641814-46fb-4a39-b53d-e13e762088af, email1=mark1@test.com, email2=mark2@test.com}, attributes=null, properties=null, consent=null)
```