### PR TITLE
Setup SDK for JitPack Publishing

### DIFF
--- a/lytics-sdk/build.gradle
+++ b/lytics-sdk/build.gradle
@@ -44,3 +44,17 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.4'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
 }
+
+afterEvaluate {
+    publishing {
+        publications {
+            // Creates a Maven publication called "release".
+            release(MavenPublication) {
+                from components.release
+                groupId = "$group"
+                artifactId = 'android-sdk'
+                version = "$version"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the maven publish plugin for publishing the SDK on JitPack.io

Here is this PR successfully being built: https://jitci.com/gh/lytics/android-sdk/5